### PR TITLE
feat(disc_send): implement handleSend with message splitting, embed, and attachment

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { handleSend } from "./send.ts";
 
 const KILL_SWITCH_PATH = join(homedir(), ".claude", "discord-bot.kill");
 
@@ -31,6 +32,14 @@ export const TOOLS: Tool[] = [
         message: {
           type: "string",
           description: "The message content to send",
+        },
+        embed: {
+          type: "string",
+          description: "Optional embed in 'title:body' format (split on first colon)",
+        },
+        attach_path: {
+          type: "string",
+          description: "Optional local file path to attach to the last message chunk",
         },
       },
       required: ["channel_id", "message"],
@@ -146,7 +155,7 @@ const HANDLERS: Record<
   string,
   (params: Record<string, unknown>) => Promise<string>
 > = {
-  disc_send: async (_params) => "not implemented",
+  disc_send: handleSend,
   disc_read: async (_params) => "not implemented",
   disc_list: async (_params) => "not implemented",
   disc_resolve: async (_params) => "not implemented",

--- a/send.ts
+++ b/send.ts
@@ -1,0 +1,177 @@
+/**
+ * send.ts — handleSend: primary outbound tool for disc_send.
+ *
+ * Handles:
+ *  - Kill switch check
+ *  - Message splitting into ≤2000-char chunks with (1/N) prefixes
+ *  - Optional embed (format "title:body")
+ *  - Optional file attachment via multipart FormData on the last chunk
+ */
+
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { getToken } from "./config.ts";
+import { DISCORD_BASE } from "./api.ts";
+import { discordFetch } from "./api.ts";
+import { checkKillSwitch, killError } from "./kill.ts";
+
+const MAX_CHUNK = 2000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SendParams {
+  channel_id: string;
+  message: string;
+  embed?: string;
+  attach_path?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Split `text` into chunks of ≤ maxLen characters on word boundaries
+ * (falls back to hard-split if a single word exceeds maxLen).
+ */
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxLen) {
+    // Try to split at the last space within maxLen
+    let splitAt = remaining.lastIndexOf(" ", maxLen);
+    if (splitAt <= 0) {
+      splitAt = maxLen;
+    }
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).replace(/^ /, "");
+  }
+
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+
+  return chunks;
+}
+
+/**
+ * Parse an embed string of the form "title:body" (split on first colon only).
+ */
+function parseEmbed(embed: string): { title: string; description: string } {
+  const colonIdx = embed.indexOf(":");
+  if (colonIdx === -1) {
+    return { title: embed, description: "" };
+  }
+  return {
+    title: embed.slice(0, colonIdx),
+    description: embed.slice(colonIdx + 1),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleSend
+// ---------------------------------------------------------------------------
+
+export async function handleSend(
+  params: Record<string, unknown>
+): Promise<string> {
+  const channel_id = params.channel_id as string;
+  const message = params.message as string;
+  const embed = params.embed as string | undefined;
+  const attach_path = params.attach_path as string | undefined;
+
+  // Kill switch check
+  const killState = checkKillSwitch();
+  if (killState.active) {
+    return killError(killState);
+  }
+
+  // Split message into ≤2000-char raw chunks
+  const rawChunks = splitMessage(message, MAX_CHUNK);
+  const n = rawChunks.length;
+
+  // Label each chunk if there are multiple
+  const labeledChunks =
+    n === 1
+      ? rawChunks
+      : rawChunks.map((chunk, i) => `(${i + 1}/${n}) ${chunk}`);
+
+  // Send all chunks except the last via plain JSON
+  for (let i = 0; i < labeledChunks.length - 1; i++) {
+    const result = await discordFetch(`/channels/${channel_id}/messages`, {
+      method: "POST",
+      body: JSON.stringify({ content: labeledChunks[i] }),
+    });
+    if (!result.ok) {
+      return `Error sending chunk ${i + 1}/${n}: ${result.error}`;
+    }
+  }
+
+  // Send the last chunk — may include embed and/or attachment
+  const lastChunk = labeledChunks[labeledChunks.length - 1];
+
+  if (attach_path) {
+    // Multipart FormData for attachment
+    const token = getToken();
+    const fileBytes = readFileSync(attach_path);
+    const fileName = basename(attach_path);
+
+    const form = new FormData();
+
+    const payload: Record<string, unknown> = { content: lastChunk };
+    if (embed) {
+      const { title, description } = parseEmbed(embed);
+      payload.embeds = [{ title, description }];
+    }
+
+    form.append(
+      "payload_json",
+      new Blob([JSON.stringify(payload)], { type: "application/json" }),
+      "payload.json"
+    );
+    form.append("files[0]", new Blob([fileBytes]), fileName);
+
+    let response: Response;
+    try {
+      response = await fetch(`${DISCORD_BASE}/channels/${channel_id}/messages`, {
+        method: "POST",
+        headers: { Authorization: `Bot ${token}` },
+        body: form,
+      });
+    } catch (err) {
+      return `Network error: ${err instanceof Error ? err.message : String(err)}`;
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      return `Error sending attachment: HTTP ${response.status}: ${body}`.trim();
+    }
+
+    return `Message sent to ${channel_id} (${n} chunk${n !== 1 ? "s" : ""}, with attachment)`;
+  }
+
+  // Plain JSON last chunk (possibly with embed)
+  const body: Record<string, unknown> = { content: lastChunk };
+  if (embed) {
+    const { title, description } = parseEmbed(embed);
+    body.embeds = [{ title, description }];
+  }
+
+  const result = await discordFetch(`/channels/${channel_id}/messages`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  if (!result.ok) {
+    return `Error sending message: ${result.error}`;
+  }
+
+  return `Message sent to ${channel_id} (${n} chunk${n !== 1 ? "s" : ""})`;
+}

--- a/tests/send.test.ts
+++ b/tests/send.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for send.ts (handleSend)
+ *
+ * Uses real kill files for kill switch tests.
+ * Mocks globalThis.fetch for network call tests.
+ *
+ * Tests:
+ *  - single message    — ≤2000 chars → 1 API call
+ *  - split 2-part      — 2001 chars → 2 calls, labeled (1/2), (2/2)
+ *  - kill active       — kill switch active → 0 API calls, error returned
+ *  - embed in last     — embed param → embeds object in final call
+ *  - attach path       — attach_path → multipart FormData used
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, existsSync, mkdirSync, writeSync, openSync, closeSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+import { KILL_FILE } from "../kill.ts";
+
+const claudeDir = join(homedir(), ".claude");
+
+function removeKillFile(): void {
+  try {
+    if (existsSync(KILL_FILE)) {
+      require("node:fs").unlinkSync(KILL_FILE);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+describe("disc_send — handleSend", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let savedToken: string | undefined;
+
+  beforeEach(() => {
+    mkdirSync(claudeDir, { recursive: true });
+    removeKillFile();
+    originalFetch = globalThis.fetch;
+    savedToken = process.env.DISCORD_BOT_TOKEN;
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+  });
+
+  afterEach(() => {
+    removeKillFile();
+    globalThis.fetch = originalFetch;
+    if (savedToken === undefined) {
+      delete process.env.DISCORD_BOT_TOKEN;
+    } else {
+      process.env.DISCORD_BOT_TOKEN = savedToken;
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1: single message (≤2000 chars)
+  // ---------------------------------------------------------------------------
+  test("send — single message", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "123",
+      message: "Hello, world!",
+    });
+
+    expect(calls.length).toBe(1);
+    expect(result).toContain("123");
+    expect(result).toContain("1 chunk");
+
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.content).toBe("Hello, world!");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: split 2-part (2001 chars → 2 calls, labeled (1/2) and (2/2))
+  // ---------------------------------------------------------------------------
+  test("send — split 2-part", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    // Build a message that is exactly 2001 chars — one char over the limit.
+    // Use word-friendly content so the splitter has a clean word boundary.
+    // Each word is 9 chars + space = 10 chars. 200 words = 2000 chars (with trailing space removed).
+    // We need content > 2000 chars total. We'll use a 2001-char string.
+    const longWord = "a".repeat(999);
+    const message = longWord + " " + longWord + " extra"; // 999 + 1 + 999 + 1 + 5 = 2005 chars
+
+    const result = await handleSend({
+      channel_id: "456",
+      message,
+    });
+
+    expect(calls.length).toBe(2);
+    expect(result).toContain("2 chunks");
+
+    const body1 = JSON.parse(calls[0].init.body as string);
+    const body2 = JSON.parse(calls[1].init.body as string);
+    expect(body1.content).toMatch(/^\(1\/2\)/);
+    expect(body2.content).toMatch(/^\(2\/2\)/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3: kill switch active → 0 API calls, error returned
+  // ---------------------------------------------------------------------------
+  test("send — kill active", async () => {
+    // Write a manual kill file (empty = active indefinitely)
+    writeFileSync(KILL_FILE, "", "utf-8");
+
+    const fetchSpy = mock(async () => {
+      throw new Error("Should not be called");
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "789",
+      message: "Should not send",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result).toContain("Kill switch is active");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 4: embed in last chunk
+  // ---------------------------------------------------------------------------
+  test("send — embed in last chunk", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "321",
+      message: "Check this out",
+      embed: "My Title:This is the body of the embed",
+    });
+
+    expect(calls.length).toBe(1);
+    expect(result).toContain("321");
+
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.embeds).toBeDefined();
+    expect(body.embeds.length).toBe(1);
+    expect(body.embeds[0].title).toBe("My Title");
+    expect(body.embeds[0].description).toBe("This is the body of the embed");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 5: attach path → multipart FormData used
+  // ---------------------------------------------------------------------------
+  test("send — attach path", async () => {
+    const calls: { url: string; init: RequestInit; bodyType: string }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init, bodyType: init.body?.constructor?.name ?? "unknown" });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    // Create a temp file to attach
+    const tmpFile = join(tmpdir(), "test-attach.txt");
+    writeFileSync(tmpFile, "hello attachment", "utf-8");
+
+    const result = await handleSend({
+      channel_id: "654",
+      message: "Here is a file",
+      attach_path: tmpFile,
+    });
+
+    expect(calls.length).toBe(1);
+    expect(result).toContain("attachment");
+
+    // Verify FormData was used, not plain JSON string
+    const { body } = calls[0].init;
+    expect(body).toBeInstanceOf(FormData);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `disc_send` — the primary outbound tool. Handles kill switch check, message splitting (≤2000-char chunks with `(N/M)` labels), optional embed in `title:body` format, and optional file attachment via multipart FormData.

## Changes

- `send.ts` — `handleSend()`, `splitMessage()`, `parseEmbed()`; direct fetch for multipart, `discordFetch` for JSON
- `tests/send.test.ts` — 5 unit tests (single, split-2, kill active, embed, attach)
- `index.ts` — import `handleSend`, wire into `HANDLERS.disc_send`, add `embed`/`attach_path` to tool schema

## Test Results

```
make ci: 31 pass, 0 fail [180ms]
```

Closes #6

Generated with [Claude Code](https://claude.com/claude-code)