### PR TITLE
feat(disc_resolve): implement handleResolve with #-strip and case-insensitive match

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { handleSend } from "./send.ts";
 import { handleRead } from "./read.ts";
+import { handleResolve } from "./resolve.ts";
 
 const KILL_SWITCH_PATH = join(homedir(), ".claude", "discord-bot.kill");
 
@@ -159,7 +160,7 @@ const HANDLERS: Record<
   disc_send: handleSend,
   disc_read: async (params) => handleRead(params),
   disc_list: async (_params) => "not implemented",
-  disc_resolve: async (_params) => "not implemented",
+  disc_resolve: handleResolve,
   disc_create_channel: async (_params) => "not implemented",
   disc_create_thread: async (_params) => "not implemented",
 };

--- a/resolve.ts
+++ b/resolve.ts
@@ -1,0 +1,68 @@
+/**
+ * resolve.ts — handleResolve for the disc MCP server.
+ *
+ * Resolves a channel name to its ID within a guild.
+ * Normalizes input: strips leading '#', lowercases before comparison.
+ */
+
+import { discordFetch } from "./api.ts";
+import { checkKillSwitch, killError } from "./kill.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DiscordChannel {
+  id: string;
+  name: string;
+  type: number;
+}
+
+// ---------------------------------------------------------------------------
+// handleResolve
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a disc_resolve tool call.
+ *
+ * @param params  Tool parameters: name (required), guild_id (required)
+ * @returns       Channel ID string on match, or descriptive error string
+ */
+export async function handleResolve(
+  params: Record<string, unknown>
+): Promise<string> {
+  // Check kill switch
+  const kill = checkKillSwitch();
+  if (kill.active) {
+    return killError(kill);
+  }
+
+  // Extract params — tool schema uses "name" and "guild_id"
+  const name = params.name as string;
+  const guild_id = params.guild_id as string;
+
+  // Normalize: strip leading '#' and lowercase
+  const normalizedName = name.replace(/^#/, "").toLowerCase();
+
+  // GET /guilds/{guild_id}/channels
+  const result = await discordFetch<DiscordChannel[]>(
+    `/guilds/${guild_id}/channels`
+  );
+
+  if (!result.ok) {
+    return `Error: ${result.error}`;
+  }
+
+  const channels = result.data;
+
+  // Find the matching channel (case-insensitive, # stripped)
+  const match = channels.find(
+    (channel) => channel.name.toLowerCase() === normalizedName
+  );
+
+  if (!match) {
+    return `Channel '#${normalizedName}' not found in guild`;
+  }
+
+  return match.id;
+}

--- a/tests/resolve.test.ts
+++ b/tests/resolve.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for resolve.ts — handleResolve
+ *
+ * Uses globalThis.fetch mocking for network calls.
+ * Uses real kill files for the kill switch test.
+ *
+ * Tests:
+ *  - resolve — match found       → returns correct channel ID
+ *  - resolve — strips hash prefix → #agent-ops matches agent-ops
+ *  - resolve — case insensitive  → Agent-Ops matches agent-ops
+ *  - resolve — not found         → descriptive error string
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { KILL_FILE } from "../kill.ts";
+
+const claudeDir = join(homedir(), ".claude");
+
+function removeKillFile(): void {
+  try {
+    if (existsSync(KILL_FILE)) {
+      require("node:fs").unlinkSync(KILL_FILE);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// Sample guild channels returned by Discord API
+const SAMPLE_CHANNELS = [
+  { id: "111", name: "general", type: 0 },
+  { id: "222", name: "agent-ops", type: 0 },
+  { id: "333", name: "announcements", type: 0 },
+];
+
+describe("resolve", () => {
+  let savedToken: string | undefined;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    mkdirSync(claudeDir, { recursive: true });
+    removeKillFile();
+    savedToken = process.env.DISCORD_BOT_TOKEN;
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    removeKillFile();
+    if (savedToken === undefined) {
+      delete process.env.DISCORD_BOT_TOKEN;
+    } else {
+      process.env.DISCORD_BOT_TOKEN = savedToken;
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1: match found — returns correct channel ID
+  // ---------------------------------------------------------------------------
+  test("resolve — match found", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(SAMPLE_CHANNELS), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleResolve } = await import("../resolve.ts");
+
+    const result = await handleResolve({ name: "agent-ops", guild_id: "guild-1" });
+
+    expect(result).toBe("222");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: strips leading '#' — #agent-ops matches agent-ops
+  // ---------------------------------------------------------------------------
+  test("resolve — strips hash prefix", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(SAMPLE_CHANNELS), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleResolve } = await import("../resolve.ts");
+
+    const result = await handleResolve({ name: "#agent-ops", guild_id: "guild-1" });
+
+    expect(result).toBe("222");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3: case insensitive — Agent-Ops matches agent-ops
+  // ---------------------------------------------------------------------------
+  test("resolve — case insensitive", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(SAMPLE_CHANNELS), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleResolve } = await import("../resolve.ts");
+
+    const result = await handleResolve({ name: "Agent-Ops", guild_id: "guild-1" });
+
+    expect(result).toBe("222");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 4: not found — descriptive error string
+  // ---------------------------------------------------------------------------
+  test("resolve — not found", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(SAMPLE_CHANNELS), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleResolve } = await import("../resolve.ts");
+
+    const result = await handleResolve({ name: "nonexistent-channel", guild_id: "guild-1" });
+
+    expect(result).toBe("Channel '#nonexistent-channel' not found in guild");
+  });
+});


### PR DESCRIPTION
## Summary

Implements `disc_resolve` — resolves a channel name to its ID within a guild. Handles `#` prefix stripping and case-insensitive matching.

## Changes

- `resolve.ts` — `handleResolve()`: kill switch check, `GET /guilds/{id}/channels`, `#`-strip + lowercase normalization, channel ID return or not-found message
- `tests/resolve.test.ts` — 4 unit tests (match found, strips hash, case insensitive, not found)
- `index.ts` — import `handleResolve`, wire into `HANDLERS.disc_resolve`

## Test Results

```
make ci: 39 pass, 0 fail [188ms]
```

Closes #8

Generated with [Claude Code](https://claude.com/claude-code)