### PR TITLE
feat(disc_list): implement handleList with type filtering and position sorting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { handleSend } from "./send.ts";
 import { handleRead } from "./read.ts";
+import { handleList } from "./list.ts";
 import { handleResolve } from "./resolve.ts";
 
 const KILL_SWITCH_PATH = join(homedir(), ".claude", "discord-bot.kill");
@@ -67,13 +68,18 @@ export const TOOLS: Tool[] = [
   },
   {
     name: "disc_list",
-    description: "List all channels in a Discord guild",
+    description: "List all channels in a Discord guild, filtered by type",
     inputSchema: {
       type: "object" as const,
       properties: {
         guild_id: {
           type: "string",
           description: "The Discord guild (server) ID to list channels for",
+        },
+        type: {
+          type: "string",
+          enum: ["text", "voice", "category"],
+          description: "Channel type to list (default: text)",
         },
       },
       required: ["guild_id"],
@@ -159,7 +165,7 @@ const HANDLERS: Record<
 > = {
   disc_send: handleSend,
   disc_read: async (params) => handleRead(params),
-  disc_list: async (_params) => "not implemented",
+  disc_list: handleList,
   disc_resolve: handleResolve,
   disc_create_channel: async (_params) => "not implemented",
   disc_create_thread: async (_params) => "not implemented",

--- a/list.ts
+++ b/list.ts
@@ -1,0 +1,88 @@
+/**
+ * list.ts — handleList for the disc MCP server.
+ *
+ * Lists channels in a guild, filtered by type and sorted by position.
+ * Format per line: #name (id)
+ */
+
+import { discordFetch } from "./api.ts";
+import { checkKillSwitch, killError } from "./kill.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DiscordChannel {
+  id: string;
+  name: string;
+  type: number;
+  position: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TYPE_MAP: Record<string, number> = {
+  text: 0,
+  voice: 2,
+  category: 4,
+};
+
+const DEFAULT_TYPE = "text";
+
+// ---------------------------------------------------------------------------
+// handleList
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a disc_list tool call.
+ *
+ * @param params  Tool parameters: guild_id (required), type (optional, default "text")
+ * @returns       Formatted channel list or error message
+ */
+export async function handleList(
+  params: Record<string, unknown>
+): Promise<string> {
+  // Check kill switch
+  const kill = checkKillSwitch();
+  if (kill.active) {
+    return killError(kill);
+  }
+
+  // Extract and validate guild_id
+  const guild_id = params.guild_id;
+  if (typeof guild_id !== "string" || guild_id.trim() === "") {
+    return "Error: guild_id is required";
+  }
+
+  // Extract and resolve type
+  const typeStr =
+    typeof params.type === "string" ? params.type : DEFAULT_TYPE;
+  const typeInt = TYPE_MAP[typeStr];
+  if (typeInt === undefined) {
+    return `Error: unknown type "${typeStr}" — must be text, voice, or category`;
+  }
+
+  // GET /guilds/{guild_id}/channels
+  const result = await discordFetch<DiscordChannel[]>(
+    `/guilds/${guild_id}/channels`
+  );
+
+  if (!result.ok) {
+    return `Error: ${result.error}`;
+  }
+
+  const channels = result.data;
+
+  // Filter by type, then sort by position
+  const filtered = channels
+    .filter((ch) => ch.type === typeInt)
+    .sort((a, b) => a.position - b.position);
+
+  if (filtered.length === 0) {
+    return "No channels found";
+  }
+
+  return filtered.map((ch) => `#${ch.name} (${ch.id})`).join("\n");
+}

--- a/tests/list.test.ts
+++ b/tests/list.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for list.ts — handleList
+ *
+ * Uses globalThis.fetch mocking for network calls.
+ * Uses real kill files for the kill switch test.
+ *
+ * Tests cover:
+ *  - list — default type is text → only type=0 channels returned when no type param given
+ *  - list — filters by voice     → only type=2 channels returned
+ *  - list — sorted by position   → channels in ascending position order
+ *  - list — kill active          → error returned, no API call made
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { KILL_FILE } from "../kill.ts";
+
+const claudeDir = join(homedir(), ".claude");
+
+function removeKillFile(): void {
+  try {
+    if (existsSync(KILL_FILE)) {
+      require("node:fs").unlinkSync(KILL_FILE);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// Sample channels — mix of text (0), voice (2), and category (4)
+const SAMPLE_CHANNELS = [
+  { id: "100", name: "general", type: 0, position: 2 },
+  { id: "101", name: "announcements", type: 0, position: 0 },
+  { id: "200", name: "voice-lobby", type: 2, position: 1 },
+  { id: "201", name: "voice-gaming", type: 2, position: 3 },
+  { id: "300", name: "category-one", type: 4, position: 0 },
+];
+
+describe("list", () => {
+  let savedToken: string | undefined;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    mkdirSync(claudeDir, { recursive: true });
+    removeKillFile();
+    savedToken = process.env.DISCORD_BOT_TOKEN;
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    removeKillFile();
+    if (savedToken === undefined) {
+      delete process.env.DISCORD_BOT_TOKEN;
+    } else {
+      process.env.DISCORD_BOT_TOKEN = savedToken;
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  test("list — default type is text", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(SAMPLE_CHANNELS), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleList } = await import("../list.ts");
+
+    // No type param — should default to "text" (type=0)
+    const result = await handleList({ guild_id: "999" });
+
+    const lines = result.split("\n");
+    // Only type=0 channels: announcements (pos 0) and general (pos 2)
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("#announcements (101)");
+    expect(lines[1]).toBe("#general (100)");
+  });
+
+  test("list — filters by voice", async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(SAMPLE_CHANNELS), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleList } = await import("../list.ts");
+
+    const result = await handleList({ guild_id: "999", type: "voice" });
+
+    const lines = result.split("\n");
+    // Only type=2 channels: voice-lobby (pos 1) and voice-gaming (pos 3)
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe("#voice-lobby (200)");
+    expect(lines[1]).toBe("#voice-gaming (201)");
+  });
+
+  test("list — sorted by position", async () => {
+    // Channels deliberately out of position order in the API response
+    const unordered = [
+      { id: "500", name: "third", type: 0, position: 2 },
+      { id: "501", name: "first", type: 0, position: 0 },
+      { id: "502", name: "second", type: 0, position: 1 },
+    ];
+
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify(unordered), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleList } = await import("../list.ts");
+
+    const result = await handleList({ guild_id: "999" });
+
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe("#first (501)");
+    expect(lines[1]).toBe("#second (502)");
+    expect(lines[2]).toBe("#third (500)");
+  });
+
+  test("list — kill active", async () => {
+    // Engage kill switch with a future expiry
+    const futureMs = Date.now() + 60_000;
+    writeFileSync(KILL_FILE, String(futureMs), "utf-8");
+
+    let fetchCalled = false;
+    globalThis.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response("[]", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleList } = await import("../list.ts");
+
+    const result = await handleList({ guild_id: "999" });
+
+    // Should return an error string, not call the API
+    expect(result).toContain("Kill switch is active");
+    expect(fetchCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `disc_list` — lists channels in a guild filtered by type (text/voice/category), sorted by position.

## Changes

- `list.ts` — `handleList()`: kill switch, GET channels, type-map filter, position sort, `#name (id)` format
- `tests/list.test.ts` — 4 unit tests (default text, voice filter, sorted by position, kill active)
- `index.ts` — import `handleList`, wire `disc_list`, add `type` enum to schema

## Test Results

```
make ci: 43 pass, 0 fail [205ms]
```

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)