### PR TITLE
feat(disc_create_thread): implement handleCreateThread with auto_archive validation

### DIFF
--- a/create_thread.ts
+++ b/create_thread.ts
@@ -1,0 +1,84 @@
+/**
+ * create_thread.ts — handleCreateThread for the disc MCP server.
+ *
+ * Creates a public thread (type 11) in a Discord channel.
+ */
+
+import { discordFetch } from "./api.ts";
+import { checkKillSwitch, killError } from "./kill.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DiscordThread {
+  id: string;
+  name: string;
+}
+
+// Valid auto_archive_duration values per the Discord API
+const VALID_AUTO_ARCHIVE = [60, 1440, 4320, 10080] as const;
+type AutoArchiveDuration = (typeof VALID_AUTO_ARCHIVE)[number];
+
+// ---------------------------------------------------------------------------
+// handleCreateThread
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a disc_create_thread tool call.
+ *
+ * @param params  Tool parameters: channel_id (required), name (required),
+ *                auto_archive? (optional, default 1440)
+ * @returns       Confirmation string or error message
+ */
+export async function handleCreateThread(
+  params: Record<string, unknown>
+): Promise<string> {
+  // Extract and validate channel_id
+  const channel_id = params.channel_id;
+  if (typeof channel_id !== "string" || channel_id.trim() === "") {
+    return "Error: channel_id is required";
+  }
+
+  // Extract and validate name
+  const name = params.name;
+  if (typeof name !== "string" || name.trim() === "") {
+    return "Error: name is required";
+  }
+
+  // Extract auto_archive with default of 1440
+  const rawAutoArchive = params.auto_archive;
+  const auto_archive: number =
+    rawAutoArchive === undefined ? 1440 : Number(rawAutoArchive);
+
+  // Validate auto_archive is one of the allowed values
+  if (!(VALID_AUTO_ARCHIVE as readonly number[]).includes(auto_archive)) {
+    return `Error: auto_archive must be one of ${VALID_AUTO_ARCHIVE.join(", ")}`;
+  }
+
+  // Check kill switch
+  const kill = checkKillSwitch();
+  if (kill.active) {
+    return killError(kill);
+  }
+
+  // POST /channels/{channel_id}/threads
+  const result = await discordFetch<DiscordThread>(
+    `/channels/${channel_id}/threads`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        name,
+        auto_archive_duration: auto_archive as AutoArchiveDuration,
+        type: 11,
+      }),
+    }
+  );
+
+  if (!result.ok) {
+    return `Error: ${result.error}`;
+  }
+
+  const thread = result.data;
+  return `Created thread '${name}' (${thread.id})`;
+}

--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@ import { handleRead } from "./read.ts";
 import { handleList } from "./list.ts";
 import { handleResolve } from "./resolve.ts";
 import { handleCreateChannel } from "./create_channel.ts";
+import { handleCreateThread } from "./create_thread.ts";
 
 const KILL_SWITCH_PATH = join(homedir(), ".claude", "discord-bot.kill");
 
@@ -169,7 +170,7 @@ const HANDLERS: Record<
   disc_list: handleList,
   disc_resolve: handleResolve,
   disc_create_channel: handleCreateChannel,
-  disc_create_thread: async (_params) => "not implemented",
+  disc_create_thread: handleCreateThread,
 };
 
 // Read DISCORD_TOKEN from environment

--- a/tests/create_thread.test.ts
+++ b/tests/create_thread.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for create_thread.ts — handleCreateThread
+ *
+ * Uses globalThis.fetch mocking for network calls.
+ * Uses real kill files for the kill switch test.
+ *
+ * Tests cover:
+ *  - create_thread — default archive: omitted auto_archive → 1440 in payload
+ *  - create_thread — invalid archive: invalid duration → error before fetch
+ *  - create_thread — valid durations: each allowed value accepted
+ *  - create_thread — kill active → error returned, no API call made
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { KILL_FILE } from "../kill.ts";
+
+const claudeDir = join(homedir(), ".claude");
+
+function removeKillFile(): void {
+  try {
+    if (existsSync(KILL_FILE)) {
+      require("node:fs").unlinkSync(KILL_FILE);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+describe("create_thread", () => {
+  let savedToken: string | undefined;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    mkdirSync(claudeDir, { recursive: true });
+    removeKillFile();
+    savedToken = process.env.DISCORD_BOT_TOKEN;
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    removeKillFile();
+    if (savedToken === undefined) {
+      delete process.env.DISCORD_BOT_TOKEN;
+    } else {
+      process.env.DISCORD_BOT_TOKEN = savedToken;
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  test("create_thread — default archive", async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({ id: "111", name: "my-thread" }),
+        { status: 200 }
+      );
+    }) as unknown as typeof fetch;
+
+    const { handleCreateThread } = await import("../create_thread.ts");
+
+    const result = await handleCreateThread({
+      channel_id: "999",
+      name: "my-thread",
+    });
+
+    // auto_archive should default to 1440
+    expect(capturedBody?.auto_archive_duration).toBe(1440);
+    expect(capturedBody?.type).toBe(11);
+    expect(capturedBody?.name).toBe("my-thread");
+    expect(result).toBe("Created thread 'my-thread' (111)");
+  });
+
+  test("create_thread — invalid archive", async () => {
+    let fetchCalled = false;
+
+    globalThis.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({ id: "0", name: "x" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleCreateThread } = await import("../create_thread.ts");
+
+    const result = await handleCreateThread({
+      channel_id: "999",
+      name: "bad-thread",
+      auto_archive: 9999,
+    });
+
+    // Should return error without calling the API
+    expect(result).toContain("Error");
+    expect(result).toContain("auto_archive");
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("create_thread — valid durations", async () => {
+    const validDurations = [60, 1440, 4320, 10080];
+
+    for (const duration of validDurations) {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        capturedBody = JSON.parse(init?.body as string) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({ id: "222", name: "duration-thread" }),
+          { status: 200 }
+        );
+      }) as unknown as typeof fetch;
+
+      const { handleCreateThread } = await import("../create_thread.ts");
+
+      const result = await handleCreateThread({
+        channel_id: "999",
+        name: "duration-thread",
+        auto_archive: duration,
+      });
+
+      expect(capturedBody?.auto_archive_duration).toBe(duration);
+      expect(result).toBe("Created thread 'duration-thread' (222)");
+    }
+  });
+
+  test("create_thread — kill active", async () => {
+    // Engage kill switch with a future expiry
+    const futureMs = Date.now() + 60_000;
+    writeFileSync(KILL_FILE, String(futureMs), "utf-8");
+
+    let fetchCalled = false;
+    globalThis.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response(JSON.stringify({ id: "0", name: "x" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleCreateThread } = await import("../create_thread.ts");
+
+    const result = await handleCreateThread({
+      channel_id: "999",
+      name: "test-thread",
+    });
+
+    // Should return an error string, not call the API
+    expect(result).toContain("Kill switch is active");
+    expect(fetchCalled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `disc_create_thread` — creates a public thread in a channel with `auto_archive_duration` validation.

## Changes

- `create_thread.ts` — `handleCreateThread()`: validates `auto_archive` ∈ [60, 1440, 4320, 10080] before any API call, kill switch check, POST `/channels/{id}/threads` (type 11 = public thread)
- `tests/create_thread.test.ts` — 4 unit tests (default archive, invalid archive, valid duration, kill active)
- `index.ts` — import `handleCreateThread`, wire `disc_create_thread`

## Test Results

```
make ci: 51 pass, 0 fail [202ms]
```

Closes #11

Generated with [Claude Code](https://claude.com/claude-code)