### PR TITLE
fix(install-remote): survive ETXTBSY by writing to temp file then mv

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -36,8 +36,16 @@ DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${BINARY_NAME}
 echo "Installing ${BINARY_NAME} ${TAG} for ${PLATFORM}..."
 
 mkdir -p "${INSTALL_DIR}"
-curl -fsSL --progress-bar "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${BINARY_NAME}"
-chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+# Download to a temp file and rename into place.
+# Direct -o on the final path would fail with ETXTBSY if the binary is
+# currently running (e.g. Claude Code has it open as an MCP subprocess).
+# rename(2) unlinks the old inode but keeps it alive for running processes.
+TMP="${INSTALL_DIR}/${BINARY_NAME}.tmp.$$"
+trap 'rm -f "${TMP}"' EXIT
+curl -fsSL --progress-bar "${DOWNLOAD_URL}" -o "${TMP}"
+chmod +x "${TMP}"
+mv -f "${TMP}" "${INSTALL_DIR}/${BINARY_NAME}"
+trap - EXIT
 
 echo "Installed to ${INSTALL_DIR}/${BINARY_NAME}"
 


### PR DESCRIPTION
## Summary

Fixes \`curl: (23) Failure writing output to destination\` when running \`./install --mcps\` while a \`disc-server\` process is active. The installer was writing directly to the final binary path with \`curl -o\`, which fails with ETXTBSY on Linux when the target is a running executable.

## Fix

Download to a temp file (\`$FINAL.tmp.$$\`), \`chmod +x\`, then \`mv -f\` into place. rename(2) unlinks the old inode while keeping it alive for any process still executing from it, so running MCP subprocesses keep working and new invocations pick up the new binary.

## Test Results

- \`./scripts/ci/validate.sh\` — 65 pass, 7 skip, 0 fail
- \`shellcheck scripts/install-remote.sh\` — clean

## Pattern Parity

Three other servers (\`discord-watcher\`, \`nerf-server\`, \`wtf-server\`) already use this pattern. This brings \`disc-server\` in line. Note: \`mcp-server-sdlc\` inherited the bug from disc-server's scaffold and has a matching fix in flight.

Closes #32

Generated with [Claude Code](https://claude.com/claude-code)