### PR TITLE
fix(send): account for label overhead in message chunking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,7 @@ Initial release of `mcp-server-discord` — a Bun/TypeScript MCP server that exp
 - `disc/SKILL.md` reduced to a ≤25-line routing stub — no bash snippets or API call patterns.
 
 ## [Unreleased]
+
+### Fixed
+
+- **`disc_send`** — Fixed message splitting bug where labeled chunks could exceed 2000 chars on content-dense input (markdown tables, code blocks). The splitter now accounts for label overhead (`(N/M) `) before splitting, ensuring all labeled chunks stay within Discord's 2000-char limit. Fixes #37.

--- a/send.ts
+++ b/send.ts
@@ -93,15 +93,29 @@ export async function handleSend(
     return killError(killState);
   }
 
-  // Split message into ≤2000-char raw chunks
-  const rawChunks = splitMessage(message, MAX_CHUNK);
-  const n = rawChunks.length;
+  // Split message into chunks, accounting for label overhead
+  // First, do a tentative split to count how many chunks we'll need
+  const tentativeChunks = splitMessage(message, MAX_CHUNK);
 
-  // Label each chunk if there are multiple
-  const labeledChunks =
-    n === 1
-      ? rawChunks
-      : rawChunks.map((chunk, i) => `(${i + 1}/${n}) ${chunk}`);
+  let labeledChunks: string[];
+  let n: number; // Total number of chunks (for return message)
+
+  if (tentativeChunks.length === 1) {
+    // Single chunk — no labels needed, use as-is
+    labeledChunks = tentativeChunks;
+    n = 1;
+  } else {
+    // Multiple chunks — need to add labels like "(1/N) ", "(2/N) ", etc.
+    // Label format: "(N/M) " where N and M can grow with message size
+    // Worst case up to 999 chunks: "(999/999) " = 11 chars
+    // Use 12 chars to include safety margin
+    const LABEL_OVERHEAD = 12;
+
+    // Re-split with reduced maxLen to ensure labeled chunks fit under MAX_CHUNK
+    const rawChunks = splitMessage(message, MAX_CHUNK - LABEL_OVERHEAD);
+    n = rawChunks.length;
+    labeledChunks = rawChunks.map((chunk, i) => `(${i + 1}/${n}) ${chunk}`);
+  }
 
   // Send all chunks except the last via plain JSON
   for (let i = 0; i < labeledChunks.length - 1; i++) {

--- a/tests/send.test.ts
+++ b/tests/send.test.ts
@@ -194,4 +194,80 @@ describe("disc_send — handleSend", () => {
     const { body } = calls[0].init;
     expect(body).toBeInstanceOf(FormData);
   });
+
+  // ---------------------------------------------------------------------------
+  // Test 6: content-dense markdown splitting (regression test for #37)
+  // ---------------------------------------------------------------------------
+  test("send — content-dense markdown stays under 2000 chars per labeled chunk", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    // Build a ~4500-char markdown table (content-dense: few word boundaries)
+    // This is the scenario reported in #37 by @percolator and cc-workflow orchestrator
+    const tableHeader = "| Column A | Column B | Column C | Column D | Column E |\n";
+    const tableSep = "|----------|----------|----------|----------|----------|\n";
+    const tableRow = "| Value 1234 | Value 5678 | Value 9012 | Value 3456 | Value 7890 |\n";
+
+    // Each row is ~69 chars. To get ~4500 chars, we need ~65 rows.
+    const tableBody = tableRow.repeat(65);
+    const message = tableHeader + tableSep + tableBody; // ~4500 chars
+
+    expect(message.length).toBeGreaterThan(4000); // Sanity check
+
+    const result = await handleSend({
+      channel_id: "999",
+      message,
+    });
+
+    expect(result).toContain("999");
+    expect(calls.length).toBeGreaterThan(1); // Should split into multiple chunks
+
+    // CRITICAL ASSERTION: Every chunk sent to Discord API must be ≤2000 chars
+    for (let i = 0; i < calls.length; i++) {
+      const body = JSON.parse(calls[i].init.body as string);
+      const content = body.content as string;
+      expect(content.length).toBeLessThanOrEqual(2000);
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 7: 100+ chunks edge case (regression test for label overhead)
+  // ---------------------------------------------------------------------------
+  test("send — 100+ chunks with label overhead stays under limit", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    // Build a ~200KB message that will produce 100+ chunks
+    // At 1988 chars per chunk (2000 - 12 label overhead), we need ~100 chunks for 198,800 chars
+    const largeMessage = "x".repeat(200000);
+
+    expect(largeMessage.length).toBeGreaterThan(198000); // Sanity check
+
+    const result = await handleSend({
+      channel_id: "888",
+      message: largeMessage,
+    });
+
+    expect(result).toContain("888");
+    expect(calls.length).toBeGreaterThanOrEqual(100); // Should produce 100+ chunks
+
+    // CRITICAL ASSERTION: Every chunk must be ≤2000 chars, even at 100+ chunk boundary
+    for (let i = 0; i < calls.length; i++) {
+      const body = JSON.parse(calls[i].init.body as string);
+      const content = body.content as string;
+      expect(content.length).toBeLessThanOrEqual(2000);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the `disc_send` auto-splitter bug where labeled chunks could exceed Discord's 2000-char limit on content-dense input (markdown tables, code blocks). The splitter now reserves space for label overhead before splitting.

## Changes

- **`send.ts`** — Updated chunking logic to do a tentative split first, then re-split with 12-char label overhead when multiple chunks are needed, ensuring all labeled chunks stay within the 2000-char Discord API constraint
- **`tests/send.test.ts`** — Added two regression tests: Test 6 (4500-char markdown table) and Test 7 (200KB message producing 100+ chunks with label overhead verification)
- **`CHANGELOG.md`** — Documented fix under `[Unreleased]`

## Linked Issues

Closes #37

## Test Plan

- `./scripts/ci/validate.sh` passed (TypeScript lint, shellcheck, full test suite)
- 69 pass, 7 skip, 0 fail across 76 tests (278 assertions)
- New Test 6 verifies 4500-char content-dense markdown splits correctly
- New Test 7 verifies 200KB message with 100+ chunks stays under limit