### PR TITLE
chore(api): route disc-server through scream-hole cache proxy

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -2,15 +2,107 @@
  * api.ts — Discord REST API client for the disc MCP server.
  *
  * Provides:
- *  - DISCORD_BASE   — Discord API v10 base URL
- *  - discordFetch() — authenticated fetch wrapper with 429/4xx/5xx handling
+ *  - DISCORD_BASE      — Discord API v10 base URL (resolved lazily)
+ *  - resolveApiBase()  — health-check scream-hole, fall back to direct Discord API
+ *  - isScreamHole()    — whether the current session routes through scream-hole
+ *  - discordFetch()    — authenticated fetch wrapper with 429/4xx/5xx handling
  */
 
+import { getConfigValue } from "./config.ts";
 import { getToken } from "./config.ts";
 import { engageKillSwitch } from "./kill.ts";
 import { log } from "./logger.ts";
 
-export const DISCORD_BASE = "https://discord.com/api/v10";
+const DIRECT_DISCORD_BASE = "https://discord.com/api/v10";
+const API_SUFFIX = "/api/v10";
+const HEALTH_CHECK_TIMEOUT_MS = 2_000;
+
+// Resolved at runtime by resolveApiBase()
+let DISCORD_BASE = DIRECT_DISCORD_BASE;
+let _resolved = false;
+let _usingScreamHole = false;
+
+/**
+ * Reset routing state (used by tests only).
+ * @internal
+ */
+export function _resetRoutingState(): void {
+  DISCORD_BASE = DIRECT_DISCORD_BASE;
+  _resolved = false;
+  _usingScreamHole = false;
+}
+
+/**
+ * Whether the current session is routing through scream-hole.
+ * Only meaningful after resolveApiBase() has been called.
+ */
+export function isScreamHole(): boolean {
+  return _usingScreamHole;
+}
+
+/**
+ * Return the current DISCORD_BASE value (for callers that bypass discordFetch).
+ * Always call resolveApiBase() first or rely on discordFetch() which calls it.
+ */
+export function getDiscordBase(): string {
+  return DISCORD_BASE;
+}
+
+/**
+ * Resolve the Discord API base URL.
+ *
+ * If `scream_hole_url` is configured (via ~/.claude/discord.json or
+ * SCREAM_HOLE_URL env var), health-check the proxy and use it when healthy.
+ * Falls back to direct Discord API on failure or when unconfigured.
+ *
+ * Safe to call multiple times — resolves only once per process.
+ */
+export async function resolveApiBase(): Promise<string> {
+  if (_resolved) return DISCORD_BASE;
+  _resolved = true;
+
+  const screamHoleUrl = getConfigValue("scream_hole_url", "SCREAM_HOLE_URL", "");
+  if (!screamHoleUrl) {
+    log.info("routing", { mode: "direct", reason: "scream_hole_url not configured" });
+    return DISCORD_BASE;
+  }
+
+  // Strip trailing slashes for consistent joining
+  const baseUrl = screamHoleUrl.replace(/\/+$/, "");
+
+  // Derive the health endpoint from the raw base (not the /api/v10 suffix)
+  // The config value may already include /api/v10 — strip it to find the root
+  const rootUrl = baseUrl.replace(/\/api\/v10\/?$/, "");
+  const healthUrl = `${rootUrl}/health`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
+
+    const res = await fetch(healthUrl, { signal: controller.signal });
+    clearTimeout(timer);
+
+    if (res.ok) {
+      // Build the API base: if the configured URL already ends with /api/v10, use it as-is
+      DISCORD_BASE = baseUrl.endsWith(API_SUFFIX) ? baseUrl : `${baseUrl}${API_SUFFIX}`;
+      _usingScreamHole = true;
+      log.info("routing", { mode: "scream-hole", url: DISCORD_BASE });
+      return DISCORD_BASE;
+    }
+
+    log.warn("routing", { mode: "direct", reason: "health check failed", status: res.status, url: healthUrl });
+  } catch (err) {
+    log.warn(
+      "routing",
+      { mode: "direct", reason: "health check error", url: healthUrl },
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+
+  // Fallback to direct Discord API
+  log.info("routing", { mode: "direct", reason: "scream-hole unavailable" });
+  return DISCORD_BASE;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,6 +132,9 @@ export async function discordFetch<T = unknown>(
   path: string,
   options: RequestInit = {}
 ): Promise<DiscordResult<T>> {
+  // Ensure base URL has been resolved (no-op after first call)
+  await resolveApiBase();
+
   const token = getToken();
   const method = (options.method ?? "GET").toUpperCase();
   const startMs = Date.now();

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { resolveApiBase } from "./api.ts";
 import { handleSend } from "./send.ts";
 import { handleRead } from "./read.ts";
 import { handleList } from "./list.ts";
@@ -193,6 +194,9 @@ const server = new Server(
 );
 
 log.info("startup", { version: "1.0.0", config: { tools: TOOLS.length, kill_switch: false } });
+
+// Resolve API base URL (scream-hole or direct Discord) and log the decision
+await resolveApiBase();
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: TOOLS,

--- a/read.ts
+++ b/read.ts
@@ -6,7 +6,7 @@
  * Output is chronological (oldest first — Discord API returns newest first).
  */
 
-import { discordFetch } from "./api.ts";
+import { discordFetch, isScreamHole } from "./api.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
 
@@ -65,8 +65,13 @@ export async function handleRead(
   }
 
   // Fetch messages from Discord API
+  // Scream-hole requires after=SNOWFLAKE on message reads (returns 400 without it).
+  // When routing through scream-hole, always pass after=0 to fetch all cached messages.
+  const qs = isScreamHole()
+    ? `?limit=${limit}&after=0`
+    : `?limit=${limit}`;
   const result = await discordFetch<DiscordMessage[]>(
-    `/channels/${channel_id}/messages?limit=${limit}`
+    `/channels/${channel_id}/messages${qs}`
   );
 
   if (!result.ok) {

--- a/send.ts
+++ b/send.ts
@@ -11,7 +11,7 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { getToken } from "./config.ts";
-import { DISCORD_BASE } from "./api.ts";
+import { getDiscordBase, resolveApiBase } from "./api.ts";
 import { discordFetch } from "./api.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
@@ -160,7 +160,8 @@ export async function handleSend(
     let response: Response;
     const attachStartMs = Date.now();
     try {
-      response = await fetch(`${DISCORD_BASE}/channels/${channel_id}/messages`, {
+      await resolveApiBase();
+      response = await fetch(`${getDiscordBase()}/channels/${channel_id}/messages`, {
         method: "POST",
         headers: { Authorization: `Bot ${token}` },
         body: form,


### PR DESCRIPTION
## Summary

Routes the disc-server through the scream-hole caching proxy instead of hitting the Discord REST API directly, eliminating rate-limiting pressure when multiple agents share the same bot token.

## Changes

- **api.ts**: Replaced hardcoded `DISCORD_BASE` constant with lazy-resolved base URL via `resolveApiBase()`. Reads `scream_hole_url` from `~/.claude/discord.json` or `SCREAM_HOLE_URL` env var. Health-checks the proxy at startup (2s timeout) and locks to scream-hole for the session if healthy, falls back to direct Discord API otherwise. Handles config URLs both with and without `/api/v10` suffix. Exports `isScreamHole()`, `getDiscordBase()`, and `_resetRoutingState()` for testing.
- **read.ts**: When routing through scream-hole, appends `after=0` query param to message reads (scream-hole requires `after=SNOWFLAKE`, returns 400 without it). Direct Discord API path unchanged.
- **send.ts**: Updated attachment upload path to use `getDiscordBase()` + `resolveApiBase()` instead of the old constant import, ensuring it respects the resolved routing.
- **index.ts**: Triggers `resolveApiBase()` at startup for early routing decision logging.

## Linked Issues

Closes #41

## Test Plan

- `bun run lint` (tsc --noEmit) — clean
- `bun test` — 69 pass, 7 skip, 0 fail
- `scripts/ci/validate.sh` — full pipeline green (lint + shellcheck + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)