### PR TITLE
fix(channel): resolve channel names from discord.json config

### DIFF
--- a/channel.ts
+++ b/channel.ts
@@ -1,0 +1,34 @@
+/**
+ * channel.ts — Channel name → ID resolution for the disc MCP server.
+ *
+ * Accepts either a numeric snowflake ID or a channel name (with optional #
+ * prefix). Names are resolved from the `channels` map in ~/.claude/discord.json.
+ */
+
+import { loadDiscordConfig } from "./config.ts";
+
+const SNOWFLAKE_RE = /^\d+$/;
+
+/**
+ * Resolve a channel identifier to a snowflake ID.
+ *
+ * - All-digit string → returned as-is (already an ID)
+ * - Otherwise → strip leading '#', lowercase, look up in discord.json channels map
+ * - Returns null if the name isn't found in the config
+ */
+export function resolveChannelId(input: string): string | null {
+  const trimmed = input.trim();
+  if (SNOWFLAKE_RE.test(trimmed)) {
+    return trimmed;
+  }
+
+  const name = trimmed.replace(/^#/, "").toLowerCase();
+  const config = loadDiscordConfig();
+  const channels = config.channels as Record<string, string> | undefined;
+
+  if (channels && name in channels) {
+    return channels[name];
+  }
+
+  return null;
+}

--- a/create_thread.ts
+++ b/create_thread.ts
@@ -5,6 +5,7 @@
  */
 
 import { discordFetch } from "./api.ts";
+import { resolveChannelId } from "./channel.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
 
@@ -35,10 +36,14 @@ type AutoArchiveDuration = (typeof VALID_AUTO_ARCHIVE)[number];
 export async function handleCreateThread(
   params: Record<string, unknown>
 ): Promise<string> {
-  // Extract and validate channel_id
-  const channel_id = params.channel_id;
-  if (typeof channel_id !== "string" || channel_id.trim() === "") {
+  // Extract and validate channel_id (accepts snowflake ID or channel name)
+  const rawChannel = params.channel_id;
+  if (typeof rawChannel !== "string" || rawChannel.trim() === "") {
     return "Error: channel_id is required";
+  }
+  const channel_id = resolveChannelId(rawChannel);
+  if (!channel_id) {
+    return `Error: unknown channel "${rawChannel}" — not found in ~/.claude/discord.json channels map`;
   }
 
   // Extract and validate name

--- a/index.ts
+++ b/index.ts
@@ -34,7 +34,7 @@ export const TOOLS: Tool[] = [
       properties: {
         channel_id: {
           type: "string",
-          description: "The Discord channel ID to send the message to",
+          description: "Discord channel ID or name (e.g. '1487288523638837268' or 'agent-ops' or '#agent-ops')",
         },
         message: {
           type: "string",
@@ -60,7 +60,7 @@ export const TOOLS: Tool[] = [
       properties: {
         channel_id: {
           type: "string",
-          description: "The Discord channel ID to read messages from",
+          description: "Discord channel ID or name (e.g. '1487288523638837268' or 'agent-ops' or '#agent-ops')",
         },
         limit: {
           type: "number",
@@ -143,7 +143,7 @@ export const TOOLS: Tool[] = [
       properties: {
         channel_id: {
           type: "string",
-          description: "The Discord channel ID to create the thread in",
+          description: "Discord channel ID or name (e.g. '1487288523638837268' or 'agent-ops' or '#agent-ops')",
         },
         name: {
           type: "string",

--- a/read.ts
+++ b/read.ts
@@ -7,6 +7,7 @@
  */
 
 import { discordFetch, isScreamHole } from "./api.ts";
+import { resolveChannelId } from "./channel.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
 
@@ -49,10 +50,14 @@ export async function handleRead(
     return killError(kill);
   }
 
-  // Extract and validate channel_id
-  const channel_id = params.channel_id;
-  if (typeof channel_id !== "string" || channel_id.trim() === "") {
+  // Extract and validate channel_id (accepts snowflake ID or channel name)
+  const rawChannel = params.channel_id;
+  if (typeof rawChannel !== "string" || rawChannel.trim() === "") {
     return "Error: channel_id is required";
+  }
+  const channel_id = resolveChannelId(rawChannel);
+  if (!channel_id) {
+    return `Error: unknown channel "${rawChannel}" — not found in ~/.claude/discord.json channels map`;
   }
 
   // Extract and clamp limit

--- a/send.ts
+++ b/send.ts
@@ -13,6 +13,7 @@ import { basename } from "node:path";
 import { getToken } from "./config.ts";
 import { getDiscordBase, resolveApiBase } from "./api.ts";
 import { discordFetch } from "./api.ts";
+import { resolveChannelId } from "./channel.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
 
@@ -84,7 +85,11 @@ export async function handleSend(
   params: Record<string, unknown>
 ): Promise<string> {
   const startMs = Date.now();
-  const channel_id = params.channel_id as string;
+  const rawChannel = params.channel_id as string;
+  const channel_id = resolveChannelId(rawChannel);
+  if (!channel_id) {
+    return `Error: unknown channel "${rawChannel}" — not found in ~/.claude/discord.json channels map`;
+  }
   const message = params.message as string;
   const embed = params.embed as string | undefined;
   const attach_path = params.attach_path as string | undefined;


### PR DESCRIPTION
## Summary

disc_read, disc_send, and disc_create_thread now accept channel names in addition to snowflake IDs. Eliminates the token-burning resolve spiral agents hit when they don't know channel IDs.

## Changes

- New `channel.ts` — `resolveChannelId()`: snowflake passthrough, or name lookup from `~/.claude/discord.json` channels map
- `read.ts`, `send.ts`, `create_thread.ts` — wired through resolveChannelId
- `index.ts` — updated tool descriptions to show name examples

## Linked Issues

Closes #44

## Test Plan

- 69 pass / 0 fail / 7 skip (existing test suite)
- Built and installed binary
- Verified name resolution works with updated discord.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)