### PR TITLE
chore(ci): replace setup-bun with npm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - run: npm install -g bun@1.3.11
       - run: sudo apt-get install -y shellcheck
       - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
@@ -23,7 +23,7 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - run: npm install -g bun@1.3.11
       - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - run: npm install -g bun@1.3.11
       - run: sudo apt-get install -y shellcheck
       - run: bun install
       - run: scripts/ci/validate.sh
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - run: npm install -g bun@1.3.11
       - run: bun install
       - run: scripts/ci/build.sh "$TARGET"
         env:


### PR DESCRIPTION
## Summary

Replace `oven-sh/setup-bun@v2` with `npm install -g bun@1.3.11` in CI and release workflows. The GitHub releases CDN is intermittently returning 504, breaking all workflows. npm registry is a more reliable distribution channel.

## Changes

- Replaced `oven-sh/setup-bun@v2` with `npm install -g bun@1.3.11` in `.github/workflows/ci.yml` (lint + test jobs)
- Replaced `oven-sh/setup-bun@v2` with `npm install -g bun@1.3.11` in `.github/workflows/release.yml` (test + build jobs)

## Linked Issues

Closes: N/A

## Test Plan

- CI runs on this PR will validate that `npm install -g bun@1.3.11` correctly installs Bun and all downstream steps (lint, test) pass