### PR TITLE
fix(ci): restore .npmrc auth for bun install against GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["v*"]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -11,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm install -g bun@1.3.11
       - run: sudo apt-get install -y shellcheck
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/validate.sh
 
@@ -29,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g bun@1.3.11
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/build.sh "$TARGET"
         env:


### PR DESCRIPTION
## Summary

Fixes the regression introduced by #46 where `bun install` in the release workflow 401s against `npm.pkg.github.com` because the `setup-bun → npm install -g bun` migration dropped the implicit `.npmrc` auth the setup-bun action provided.

## Changes

- `.github/workflows/release.yml`: added `.npmrc` auth step before every `bun install` invocation (test + build jobs), plus workflow-level `permissions: { contents: read, packages: read }`.
- `.github/workflows/ci.yml`: added workflow-level `permissions: { contents: read, packages: read }` for consistency. The existing `.npmrc` step was already in place.

## Linked Issues

Closes #48

## Test Plan

- [x] `./scripts/ci/validate.sh` green in worktree (lint + shellcheck + 69 tests pass)
- [ ] This PR's CI run green (auto-verified by merge queue)
- [ ] Post-merge: push throwaway `vX.Y.Z-test` tag to verify release workflow succeeds end-to-end; delete after
