### PR TITLE
fix(disc_send): validate input + accept 'content' alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ Initial release of `mcp-server-discord` — a Bun/TypeScript MCP server that exp
 ### Fixed
 
 - **`disc_send`** — Fixed message splitting bug where labeled chunks could exceed 2000 chars on content-dense input (markdown tables, code blocks). The splitter now accounts for label overhead (`(N/M) `) before splitting, ensuring all labeled chunks stay within Discord's 2000-char limit. Fixes #37.
+- **`disc_send`** — Validate the body field before dereferencing. Prior callers that supplied a different field name (most commonly `content`, which is what the upstream Discord REST API itself uses) hit an opaque `text.length` crash inside `splitMessage`. The handler now (a) accepts `content` as an alias for `message`, and (b) returns a structured error naming the missing field plus what was actually received when neither is supplied. Schema in `index.ts` documents the alias. Fixes #50.

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,11 @@ export const TOOLS: Tool[] = [
         },
         message: {
           type: "string",
-          description: "The message content to send",
+          description: "The message content to send (canonical name)",
+        },
+        content: {
+          type: "string",
+          description: "Alias for 'message'. Accepted for parity with the upstream Discord REST API; either 'message' or 'content' may be supplied.",
         },
         embed: {
           type: "string",

--- a/send.ts
+++ b/send.ts
@@ -90,7 +90,16 @@ export async function handleSend(
   if (!channel_id) {
     return `Error: unknown channel "${rawChannel}" — not found in ~/.claude/discord.json channels map`;
   }
-  const message = params.message as string;
+  // Accept `content` as alias for `message`. The upstream Discord REST API
+  // uses `content`, so it's the dominant convention agents guess. The schema
+  // continues to advertise `message` as canonical; alias is for tolerance.
+  const message = (params.message ?? params.content) as string | undefined;
+  if (typeof message !== "string" || message.length === 0) {
+    const received = Object.keys(params).join(", ") || "no fields";
+    const err = `Error: missing required field 'message' (received: ${received}). Accepted aliases: 'content'.`;
+    log.warn("tool_call", { tool: "disc_send", ok: false, ms: Date.now() - startMs, error: "missing_message_field" });
+    return err;
+  }
   const embed = params.embed as string | undefined;
   const attach_path = params.attach_path as string | undefined;
 

--- a/tests/send.test.ts
+++ b/tests/send.test.ts
@@ -270,4 +270,91 @@ describe("disc_send — handleSend", () => {
       expect(content.length).toBeLessThanOrEqual(2000);
     }
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression: input-field handling (issue #50)
+  //
+  // Prior to #50 the handler did `params.message as string` with no validation,
+  // so any caller that supplied a different field name (e.g. `content`, which is
+  // what the upstream Discord REST API uses) hit an opaque crash inside
+  // splitMessage at `text.length`. The fix accepts `content` as an alias and
+  // returns a structured error for every other shape.
+  // ---------------------------------------------------------------------------
+  test("send — accepts 'content' as alias for 'message'", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+
+    globalThis.fetch = mock(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({ id: "msg-1" }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "123",
+      content: "Hello via content alias",
+    });
+
+    expect(calls.length).toBe(1);
+    expect(result).toContain("1 chunk");
+
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.content).toBe("Hello via content alias");
+  });
+
+  test("send — unknown body field returns structured error, never crashes", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "123",
+      body: "wrong field name",
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(result).toContain("missing required field 'message'");
+    expect(result).toContain("body"); // names what was actually received
+    expect(result).toContain("channel_id");
+  });
+
+  test("send — no body field at all returns structured error", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "123",
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(result).toContain("missing required field 'message'");
+    expect(result).toContain("channel_id");
+  });
+
+  test("send — empty message string returns structured error", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = mock(async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const { handleSend } = await import("../send.ts");
+
+    const result = await handleSend({
+      channel_id: "123",
+      message: "",
+    });
+
+    expect(fetchCalled).toBe(false);
+    expect(result).toContain("missing required field 'message'");
+  });
 });


### PR DESCRIPTION
## Summary

`disc_send` previously crashed with an opaque `MCP error -32603: undefined is not an object (evaluating 'text.length')` whenever the caller used any field name other than `message` for the body content (e.g. `content`, which is what the upstream Discord REST API itself uses, and what most LLM agents naturally guess). Two narrow fixes: accept `content` as an alias, and validate the input with a structured error so the next failure mode is self-correcting instead of opaque.

## Changes

- **`send.ts`** — `handleSend` now normalizes `params.message ?? params.content` and validates the result is a non-empty string before dereferencing. On miss, returns `Error: missing required field 'message' (received: <list>). Accepted aliases: 'content'.` and logs `missing_message_field`.
- **`index.ts`** — disc_send schema documents `content` as a non-required alias for `message`. The `required` array is unchanged (`["channel_id", "message"]`) so the canonical contract still advertises `message`; the alias is for runtime tolerance.
- **`tests/send.test.ts`** — 4 new regression tests at end of file covering: (1) `content` alias accepted, (2) unknown body field returns structured error and never reaches fetch, (3) no body field at all returns structured error, (4) empty `message` string returns structured error.
- **`CHANGELOG.md`** — entry under `[Unreleased]`/Fixed referencing #50.

## Why both fixes, not just one

- **Alias alone** would solve the immediate friction but still crash on `body` / `text` / any other guess.
- **Validation alone** would correct future agents but force every existing caller using `content` (matching the upstream Discord API) through one round-trip retry.
- **Both together**: the dominant guess works first try; every other wrong-name guess fails informatively and self-corrects. Postel's law tolerance is bounded to the one upstream-canonical alias, not arbitrary acceptance.

## Linked Issues

Closes #50

## Test Plan

- [x] `./scripts/ci/validate.sh` — 73 pass / 7 skip / 0 fail
- [x] 4 new regression tests added; all 4 pass when run inside the full bun test suite
- [x] `make build` — all 3 targets (linux-x64, darwin-arm64, darwin-x64) compile cleanly
- [x] Trivy scan — 0 HIGH/CRITICAL
- [x] Code reviewer — clean (`??` precedence sound, empty-string guard correct, schema preserved)
- [ ] Post-merge: kill the running disc-server PID + restart CC so the new binary is picked up; smoke test `disc_send({channel_id, content: "..."})` from a fresh session

## Note on test flakiness

There is one pre-existing isolation flake in `tests/send.test.ts` — "send — single message" fails when `tests/send.test.ts` is run alone, but passes inside the full `bun test` suite. Reproducible on `main` BEFORE this PR (verified via `git stash`). Not introduced by these changes; worth a separate bug if anyone bites on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;