### PR TITLE
fix(disc): sanitize lone UTF-16 surrogates both directions

### DIFF
--- a/read.ts
+++ b/read.ts
@@ -10,6 +10,7 @@ import { discordFetch, isScreamHole } from "./api.ts";
 import { resolveChannelId } from "./channel.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
+import { sanitizeSurrogates } from "./sanitize.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -96,8 +97,11 @@ export async function handleRead(
   // Discord returns newest-first — reverse for chronological output
   const chronological = [...messages].reverse();
 
+  // Sanitize inbound: a lone surrogate in a pulled message would 400 the
+  // reader's own next request once it lands in the transcript (see sanitize.ts).
   const lines = chronological.map(
-    (msg) => `[${msg.timestamp}] <${msg.author.username}>: ${msg.content}`
+    (msg) =>
+      `[${msg.timestamp}] <${sanitizeSurrogates(msg.author.username)}>: ${sanitizeSurrogates(msg.content)}`
   );
 
   const ms = Date.now() - startMs;

--- a/sanitize.test.ts
+++ b/sanitize.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test";
+import { sanitizeSurrogates } from "./sanitize.ts";
+
+const FFFD = "�";
+
+describe("sanitizeSurrogates", () => {
+  test("passes through plain ASCII unchanged", () => {
+    expect(sanitizeSurrogates("hello world")).toBe("hello world");
+  });
+
+  test("preserves a valid surrogate pair (emoji)", () => {
+    const fish = "🐟"; // 🐟 U+1F41F
+    expect(sanitizeSurrogates(`a ${fish} b`)).toBe(`a ${fish} b`);
+  });
+
+  test("replaces a lone high surrogate with U+FFFD", () => {
+    expect(sanitizeSurrogates("a\uD800b")).toBe(`a${FFFD}b`);
+  });
+
+  test("replaces a lone low surrogate with U+FFFD", () => {
+    expect(sanitizeSurrogates("a\uDC00b")).toBe(`a${FFFD}b`);
+  });
+
+  test("lone high surrogate at end of string", () => {
+    expect(sanitizeSurrogates("end\uD83D")).toBe(`end${FFFD}`);
+  });
+
+  test("high surrogate followed by a non-low char is replaced; the char survives", () => {
+    expect(sanitizeSurrogates("\uD800x")).toBe(`${FFFD}x`);
+  });
+
+  test("two high surrogates in a row: first is lone, second pairs or is lone", () => {
+    // \uD800\uD800 — neither forms a pair; both replaced
+    expect(sanitizeSurrogates("\uD800\uD800")).toBe(`${FFFD}${FFFD}`);
+  });
+
+  test("mixed valid pair and lone surrogate", () => {
+    const fish = "🐟";
+    expect(sanitizeSurrogates(`${fish}\uD800${fish}`)).toBe(`${fish}${FFFD}${fish}`);
+  });
+
+  test("empty string", () => {
+    expect(sanitizeSurrogates("")).toBe("");
+  });
+
+  test("output is JSON-serializable (the whole point)", () => {
+    // A lone surrogate is not valid in JSON; after sanitization it must serialize.
+    const poisoned = "payload \uD800 here";
+    expect(() => JSON.stringify({ content: sanitizeSurrogates(poisoned) })).not.toThrow();
+  });
+});

--- a/sanitize.ts
+++ b/sanitize.ts
@@ -1,0 +1,41 @@
+/**
+ * Lone-surrogate sanitization.
+ *
+ * A lone unpaired UTF-16 surrogate (a high surrogate U+D800–U+DBFF with no
+ * following low surrogate, or a low surrogate U+DC00–U+DFFF with no preceding
+ * high) cannot be encoded as valid JSON. When such a codepoint reaches an agent
+ * transcript it makes every subsequent API request fail with
+ * `400 ... no low surrogate in string`, hard-jamming the session (cc-workflow
+ * incident 2026-06-19). We strip them at the disc boundary in BOTH directions:
+ * inbound on `disc_read` (protect ourselves from poisoned pulls — we can't make
+ * other senders emit clean text) and outbound on `disc_send` (protect other
+ * agents — never be the one who jams someone else's session).
+ *
+ * Valid surrogate PAIRS (ordinary emoji / astral-plane characters) are left
+ * untouched; only unpaired halves are replaced with U+FFFD (the Unicode
+ * replacement character).
+ */
+
+/** Replace any unpaired UTF-16 surrogate in `s` with U+FFFD; valid pairs are preserved. */
+export function sanitizeSurrogates(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      // High surrogate: valid only if immediately followed by a low surrogate.
+      const next = i + 1 < s.length ? s.charCodeAt(i + 1) : 0;
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        out += s[i] + s[i + 1];
+        i++; // consume the paired low surrogate
+      } else {
+        out += "�";
+      }
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      // Low surrogate with no preceding high surrogate (those are consumed above).
+      out += "�";
+    } else {
+      out += s[i];
+    }
+  }
+  return out;
+}

--- a/send.ts
+++ b/send.ts
@@ -16,6 +16,7 @@ import { discordFetch } from "./api.ts";
 import { resolveChannelId } from "./channel.ts";
 import { checkKillSwitch, killError } from "./kill.ts";
 import { log } from "./logger.ts";
+import { sanitizeSurrogates } from "./sanitize.ts";
 
 const MAX_CHUNK = 2000;
 
@@ -110,9 +111,14 @@ export async function handleSend(
     return killError(killState);
   }
 
+  // Sanitize outbound: never emit a lone surrogate that would jam another
+  // agent's session once it lands in their transcript (see sanitize.ts).
+  // Done before chunking so every part is clean.
+  const safeMessage = sanitizeSurrogates(message);
+
   // Split message into chunks, accounting for label overhead
   // First, do a tentative split to count how many chunks we'll need
-  const tentativeChunks = splitMessage(message, MAX_CHUNK);
+  const tentativeChunks = splitMessage(safeMessage, MAX_CHUNK);
 
   let labeledChunks: string[];
   let n: number; // Total number of chunks (for return message)
@@ -129,10 +135,16 @@ export async function handleSend(
     const LABEL_OVERHEAD = 12;
 
     // Re-split with reduced maxLen to ensure labeled chunks fit under MAX_CHUNK
-    const rawChunks = splitMessage(message, MAX_CHUNK - LABEL_OVERHEAD);
+    const rawChunks = splitMessage(safeMessage, MAX_CHUNK - LABEL_OVERHEAD);
     n = rawChunks.length;
     labeledChunks = rawChunks.map((chunk, i) => `(${i + 1}/${n}) ${chunk}`);
   }
+
+  // Belt-and-suspenders: re-sanitize each final chunk. splitMessage slices on
+  // UTF-16 code units, so a valid surrogate pair straddling a chunk boundary
+  // would otherwise re-introduce lone halves AFTER the message-level sanitize.
+  // (No length impact — a lone surrogate → U+FFFD is one code unit either way.)
+  labeledChunks = labeledChunks.map(sanitizeSurrogates);
 
   // Send all chunks except the last via plain JSON
   for (let i = 0; i < labeledChunks.length - 1; i++) {
@@ -154,13 +166,13 @@ export async function handleSend(
     // Multipart FormData for attachment
     const token = getToken();
     const fileBytes = readFileSync(attach_path);
-    const fileName = basename(attach_path);
+    const fileName = sanitizeSurrogates(basename(attach_path));
 
     const form = new FormData();
 
     const payload: Record<string, unknown> = { content: lastChunk };
     if (embed) {
-      const { title, description } = parseEmbed(embed);
+      const { title, description } = parseEmbed(sanitizeSurrogates(embed));
       payload.embeds = [{ title, description }];
     }
 
@@ -206,7 +218,7 @@ export async function handleSend(
   // Plain JSON last chunk (possibly with embed)
   const body: Record<string, unknown> = { content: lastChunk };
   if (embed) {
-    const { title, description } = parseEmbed(embed);
+    const { title, description } = parseEmbed(sanitizeSurrogates(embed));
     body.embeds = [{ title, description }];
   }
 


### PR DESCRIPTION
## Summary
A lone unpaired UTF-16 surrogate in Discord content baked into agent `.jsonl` transcripts and 400'd every subsequent request (`no low surrogate in string`), hard-jamming the session (incident 2026-06-19). Sanitize at the disc boundary **both** directions: inbound (`disc_read`, protect us) and outbound (`disc_send`, protect other agents — don't be the bad actor).

## Changes
- New `sanitize.ts`: `sanitizeSurrogates` replaces only **unpaired** surrogates with `U+FFFD`; valid pairs (emoji/astral) untouched. 10 unit tests.
- `read.ts` inbound: sanitize `msg.content` + `msg.author.username` in the digest.
- `send.ts` outbound: sanitize message before chunking; **re-sanitize each final chunk** (splitMessage slices on UTF-16 units → a pair straddling a 2000-char boundary would re-introduce lone halves); sanitize the **embed** title/description (both call sites) and the attachment filename.

## Linked Issues
Closes #56

## Test Plan
- `bun test sanitize.test.ts` → 10/0 (lone high/low, pair-preserved, boundary, consecutive, JSON-serializable).
- `./scripts/ci/validate.sh` → 82 pass / 0 fail; `bunx tsc --noEmit` clean.
- Code-reviewed: 3 findings (unsanitized embed [both sites], split-pair re-introduction, filename) all fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)