### PR TITLE
feat(disc): per-agent webhook identity (distinct username + avatar per agent)

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -112,6 +112,16 @@ export type DiscordResult<T = unknown> =
   | { ok: true; data: T }
   | { ok: false; error: string };
 
+/**
+ * Redact the secret token from a webhook-execute path before logging.
+ * `/webhooks/{id}/{token}` → `/webhooks/{id}/***`. The webhook token is a
+ * standalone bearer credential (anyone with the URL can post), so it must never
+ * land in `~/.claude/logs/mcp.jsonl`.
+ */
+export function redactWebhookToken(path: string): string {
+  return path.replace(/(\/webhooks\/[^/]+\/)[^/?]+/, "$1***");
+}
+
 // ---------------------------------------------------------------------------
 // discordFetch
 // ---------------------------------------------------------------------------
@@ -130,30 +140,35 @@ export type DiscordResult<T = unknown> =
  */
 export async function discordFetch<T = unknown>(
   path: string,
-  options: RequestInit = {}
+  options: RequestInit & { skipAuth?: boolean } = {}
 ): Promise<DiscordResult<T>> {
   // Ensure base URL has been resolved (no-op after first call)
   await resolveApiBase();
 
-  const token = getToken();
-  const method = (options.method ?? "GET").toUpperCase();
+  const { skipAuth, ...fetchOptions } = options;
+  const method = (fetchOptions.method ?? "GET").toUpperCase();
+  const logPath = redactWebhookToken(path); // never log webhook tokens
   const startMs = Date.now();
 
-  const headers = new Headers(options.headers as HeadersInit | undefined);
-  headers.set("Authorization", `Bot ${token}`);
-  if (!headers.has("Content-Type") && options.body !== undefined) {
+  const headers = new Headers(fetchOptions.headers as HeadersInit | undefined);
+  // Webhook EXECUTE (POST /webhooks/{id}/{token}) authenticates via the URL
+  // token, not the bot token — skipAuth omits the Bot header for those calls.
+  if (!skipAuth) {
+    headers.set("Authorization", `Bot ${getToken()}`);
+  }
+  if (!headers.has("Content-Type") && fetchOptions.body !== undefined) {
     headers.set("Content-Type", "application/json");
   }
 
   let response: Response;
   try {
     response = await fetch(`${DISCORD_BASE}${path}`, {
-      ...options,
+      ...fetchOptions,
       headers,
     });
   } catch (err) {
     const ms = Date.now() - startMs;
-    log.error("api_call", { method, endpoint: path, status: 0, ms, service: "discord" }, err instanceof Error ? err.message : String(err));
+    log.error("api_call", { method, endpoint: logPath, status: 0, ms, service: "discord" }, err instanceof Error ? err.message : String(err));
     return {
       ok: false,
       error: `Network error: ${err instanceof Error ? err.message : String(err)}`,
@@ -167,7 +182,7 @@ export async function discordFetch<T = unknown>(
     const retryAfter = parseFloat(response.headers.get("Retry-After") ?? "5");
     const cooldownSec = Math.min(Math.ceil(retryAfter) + 5, 60); // cap at 60s
     const expiryMs = Date.now() + cooldownSec * 1000;
-    log.warn("api_call", { method, endpoint: path, status: 429, ms, service: "discord", retry: retryAfter });
+    log.warn("api_call", { method, endpoint: logPath, status: 429, ms, service: "discord", retry: retryAfter });
     engageKillSwitch(expiryMs);
 
     const body = await response.text().catch(() => "");
@@ -179,7 +194,7 @@ export async function discordFetch<T = unknown>(
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");
-    log.error("api_call", { method, endpoint: path, status: response.status, ms, service: "discord" });
+    log.error("api_call", { method, endpoint: logPath, status: response.status, ms, service: "discord" });
     return {
       ok: false,
       error: `HTTP ${response.status}: ${body}`.trim(),
@@ -189,7 +204,7 @@ export async function discordFetch<T = unknown>(
   // Parse JSON response
   try {
     const data = (await response.json()) as T;
-    log.info("api_call", { method, endpoint: path, status: response.status, ms, service: "discord" });
+    log.info("api_call", { method, endpoint: logPath, status: response.status, ms, service: "discord" });
     return { ok: true, data };
   } catch (err) {
     return {

--- a/identity.test.ts
+++ b/identity.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "bun:test";
+import {
+  webhookUsername,
+  webhookAvatarUrl,
+  identityFilePath,
+} from "./identity.ts";
+import { createHash } from "node:crypto";
+
+describe("webhookUsername", () => {
+  test("combines dev_name + dev_avatar", () => {
+    expect(webhookUsername({ dev_name: "babelfish", dev_avatar: "🐠" })).toBe("babelfish 🐠");
+  });
+
+  test("falls back to dev_name when no avatar", () => {
+    expect(webhookUsername({ dev_name: "neuron" })).toBe("neuron");
+  });
+
+  test("neutralizes the banned 'discord' substring (Discord rejects it)", () => {
+    const out = webhookUsername({ dev_name: "discord-bot" });
+    expect(out.toLowerCase()).not.toContain("discord");
+    // and it must not be a no-op
+    expect(out).not.toBe("discord-bot");
+  });
+
+  test("neutralizes the banned 'clyde' substring", () => {
+    const out = webhookUsername({ dev_name: "clyde-jr" });
+    expect(out.toLowerCase()).not.toContain("clyde");
+  });
+
+  test("caps at 80 characters", () => {
+    const long = "x".repeat(200);
+    expect(webhookUsername({ dev_name: long }).length).toBe(80);
+  });
+});
+
+describe("webhookAvatarUrl", () => {
+  test("is deterministic for a given dev-name", () => {
+    expect(webhookAvatarUrl("babelfish")).toBe(webhookAvatarUrl("babelfish"));
+  });
+
+  test("differs by dev-name", () => {
+    expect(webhookAvatarUrl("babelfish")).not.toBe(webhookAvatarUrl("neuron"));
+  });
+
+  test("url-encodes the seed", () => {
+    expect(webhookAvatarUrl("a b")).toContain("seed=a%20b");
+  });
+
+  test("honors a custom style", () => {
+    expect(webhookAvatarUrl("x", "identicon")).toContain("/9.x/identicon/");
+  });
+});
+
+describe("identityFilePath", () => {
+  test("keys by md5 of the project root (matches the /name skill)", () => {
+    const root = "/home/bakerb/sandbox/github/mcp-server-discord";
+    const hash = createHash("md5").update(root).digest("hex");
+    expect(identityFilePath(root)).toContain(`claude-agent-${hash}.json`);
+  });
+});

--- a/identity.test.ts
+++ b/identity.test.ts
@@ -31,6 +31,14 @@ describe("webhookUsername", () => {
     const long = "x".repeat(200);
     expect(webhookUsername({ dev_name: long }).length).toBe(80);
   });
+
+  test("trims surrounding whitespace", () => {
+    expect(webhookUsername({ dev_name: "  spacey  " })).toBe("spacey");
+  });
+
+  test("a whitespace-only name reduces to empty (send.ts then falls back to bot path)", () => {
+    expect(webhookUsername({ dev_name: "   " })).toBe("");
+  });
 });
 
 describe("webhookAvatarUrl", () => {

--- a/identity.ts
+++ b/identity.ts
@@ -66,11 +66,11 @@ export function readAgentIdentity(): AgentIdentity | null {
  * Surrogate sanitization is applied by the caller (shared with `disc_send`).
  */
 export function webhookUsername(id: AgentIdentity): string {
-  let name = id.dev_avatar ? `${id.dev_name} ${id.dev_avatar}` : id.dev_name;
+  let name = (id.dev_avatar ? `${id.dev_name} ${id.dev_avatar}` : id.dev_name).trim();
   // Discord rejects webhook usernames containing "clyde" or "discord" — neutralize
   // the banned substrings without dropping characters (keeps the name recognizable).
   name = name.replace(/clyde/gi, "clyba").replace(/discord/gi, "disc0rd");
-  if (name.length > 80) name = name.slice(0, 80);
+  if (name.length > 80) name = name.slice(0, 80).trim();
   return name;
 }
 

--- a/identity.ts
+++ b/identity.ts
@@ -1,0 +1,85 @@
+/**
+ * Agent session identity → Discord webhook persona.
+ *
+ * The `/name` skill writes a per-project identity to
+ * `/tmp/claude-agent-<md5(project_root)>.json` (`{ dev_name, dev_avatar, dev_team }`).
+ * When webhook identity is enabled, `disc_send` posts each message as that
+ * agent's own `username` + `avatar` so a human juggling many concurrent agents
+ * can tell them apart at a glance — without moving any text out of `content`
+ * (so other agents still read the message normally).
+ */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface AgentIdentity {
+  dev_name: string;
+  dev_avatar?: string;
+  dev_team?: string;
+}
+
+/** Resolve the project root (git toplevel, else cwd) — same key the /name skill uses. */
+function projectRoot(): string {
+  try {
+    return execSync("git rev-parse --show-toplevel", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+/** Path to the identity file for the current project, keyed by md5 of the project root. */
+export function identityFilePath(root: string = projectRoot()): string {
+  const hash = createHash("md5").update(root).digest("hex");
+  return join(tmpdir(), `claude-agent-${hash}.json`);
+}
+
+/**
+ * Read the current session's agent identity, or null if none is established
+ * (no `/name` has run, or the file is missing/malformed). Callers fall back to
+ * the default bot identity when this returns null.
+ */
+export function readAgentIdentity(): AgentIdentity | null {
+  try {
+    const raw = readFileSync(identityFilePath(), "utf8");
+    const obj = JSON.parse(raw) as Partial<AgentIdentity>;
+    if (typeof obj.dev_name === "string" && obj.dev_name.length > 0) {
+      return {
+        dev_name: obj.dev_name,
+        dev_avatar: typeof obj.dev_avatar === "string" ? obj.dev_avatar : undefined,
+        dev_team: typeof obj.dev_team === "string" ? obj.dev_team : undefined,
+      };
+    }
+  } catch {
+    // missing / unreadable / malformed → no identity
+  }
+  return null;
+}
+
+/**
+ * Webhook `username` for an identity. Discord bans the substrings `clyde` and
+ * `discord` (case-insensitive) in webhook usernames, and caps at 80 chars.
+ * Surrogate sanitization is applied by the caller (shared with `disc_send`).
+ */
+export function webhookUsername(id: AgentIdentity): string {
+  let name = id.dev_avatar ? `${id.dev_name} ${id.dev_avatar}` : id.dev_name;
+  // Discord rejects webhook usernames containing "clyde" or "discord" — neutralize
+  // the banned substrings without dropping characters (keeps the name recognizable).
+  name = name.replace(/clyde/gi, "clyba").replace(/discord/gi, "disc0rd");
+  if (name.length > 80) name = name.slice(0, 80);
+  return name;
+}
+
+/**
+ * Deterministic avatar URL for an agent: a stable, colorful icon seeded by the
+ * dev-name (DiceBear, no hosting needed). Same agent → same avatar forever.
+ * The style is overridable via ~/.claude/discord.json `webhook_avatar_style`.
+ */
+export function webhookAvatarUrl(devName: string, style = "bottts"): string {
+  const seed = encodeURIComponent(devName);
+  return `https://api.dicebear.com/9.x/${style}/png?seed=${seed}`;
+}

--- a/send.ts
+++ b/send.ts
@@ -10,7 +10,9 @@
 
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
-import { getToken } from "./config.ts";
+import { getToken, getConfigValue } from "./config.ts";
+import { readAgentIdentity, webhookUsername, webhookAvatarUrl } from "./identity.ts";
+import { executeWebhook } from "./webhook.ts";
 import { getDiscordBase, resolveApiBase } from "./api.ts";
 import { discordFetch } from "./api.ts";
 import { resolveChannelId } from "./channel.ts";
@@ -145,6 +147,45 @@ export async function handleSend(
   // would otherwise re-introduce lone halves AFTER the message-level sanitize.
   // (No length impact — a lone surrogate → U+FFFD is one code unit either way.)
   labeledChunks = labeledChunks.map(sanitizeSurrogates);
+
+  // Webhook identity path (#55): post as the agent's own username + avatar so a
+  // human juggling many agents can tell them apart. Gated behind config; skips
+  // when no /name identity exists or an attachment is present (attachments stay
+  // on the bot path for now). Text stays in `content` — agents read it normally.
+  const identity = readAgentIdentity();
+  const webhookFlag =
+    getConfigValue("webhook_identity", "DISC_WEBHOOK_IDENTITY", "") !== "";
+  // Empty/whitespace-only names (after sanitize + banned-substring neutralization)
+  // would make Discord reject the webhook execute — fall back to the bot path.
+  const username = identity ? sanitizeSurrogates(webhookUsername(identity)) : "";
+  if (webhookFlag && identity && username.length > 0 && !attach_path) {
+    const avatarUrl = webhookAvatarUrl(
+      identity.dev_name,
+      getConfigValue("webhook_avatar_style", "DISC_WEBHOOK_AVATAR_STYLE", "bottts")
+    );
+    let embeds: unknown[] | undefined;
+    if (embed) {
+      const { title, description } = parseEmbed(sanitizeSurrogates(embed));
+      embeds = [{ title, description }];
+    }
+    for (let i = 0; i < labeledChunks.length; i++) {
+      const isLast = i === labeledChunks.length - 1;
+      const res = await executeWebhook(channel_id, {
+        username,
+        avatarUrl,
+        content: labeledChunks[i],
+        embeds: isLast ? embeds : undefined,
+      });
+      if (!res.ok) {
+        const ms = Date.now() - startMs;
+        log.warn("tool_call", { tool: "disc_send", ok: false, ms, error: res.error });
+        return `Error sending chunk ${i + 1}/${n} via webhook: ${res.error}`;
+      }
+    }
+    const ms = Date.now() - startMs;
+    log.info("tool_call", { tool: "disc_send", ok: true, ms, chunks: n, identity: identity.dev_name });
+    return `Message sent to ${channel_id} as ${username} (${n} chunk${n !== 1 ? "s" : ""})`;
+  }
 
   // Send all chunks except the last via plain JSON
   for (let i = 0; i < labeledChunks.length - 1; i++) {

--- a/tests/webhook.test.ts
+++ b/tests/webhook.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for webhook.ts (#55) — per-agent webhook identity lifecycle.
+ * Mocks globalThis.fetch (the repo convention); no real network.
+ */
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { _resetRoutingState, redactWebhookToken } from "../api.ts";
+import {
+  getOrCreateWebhook,
+  executeWebhook,
+  _resetWebhookCache,
+  FLEET_WEBHOOK_NAME,
+} from "../webhook.ts";
+
+const CH = "100";
+const WH = { id: "wh1", token: "tok1" };
+
+let originalFetch: typeof fetch;
+let savedToken: string | undefined;
+let calls: Array<{ url: string; method: string; headers: Headers; body: string }>;
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Record every fetch and dispatch by URL/method; `execMode` controls the execute response. */
+function installFetch(opts: {
+  list?: unknown[]; // GET /channels/{id}/webhooks
+  execStatus?: number[]; // sequence of execute statuses (e.g. [404, 200])
+}) {
+  const execStatuses = [...(opts.execStatus ?? [200])];
+  globalThis.fetch = mock(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      calls.push({
+        url,
+        method,
+        headers: new Headers(init?.headers as HeadersInit | undefined),
+        body: typeof init?.body === "string" ? init.body : "",
+      });
+      // Webhook EXECUTE: /webhooks/{id}/{token}
+      if (/\/webhooks\/[^/]+\/[^/?]+/.test(url) && method === "POST") {
+        const st = execStatuses.shift() ?? 200;
+        return json(st === 200 ? { id: "msg1" } : { message: "Unknown Webhook" }, st);
+      }
+      // Webhook LIST: GET /channels/{id}/webhooks
+      if (/\/channels\/[^/]+\/webhooks$/.test(url) && method === "GET") {
+        return json(opts.list ?? []);
+      }
+      // Webhook CREATE: POST /channels/{id}/webhooks
+      if (/\/channels\/[^/]+\/webhooks$/.test(url) && method === "POST") {
+        return json({ id: WH.id, name: FLEET_WEBHOOK_NAME, token: WH.token });
+      }
+      // Anything else (e.g. scream-hole health check) → unhealthy → falls to direct.
+      return new Response("nope", { status: 503 });
+    }
+  ) as unknown as typeof fetch;
+}
+
+describe("webhook.ts", () => {
+  beforeEach(() => {
+    savedToken = process.env.DISCORD_BOT_TOKEN;
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token";
+    originalFetch = globalThis.fetch;
+    calls = [];
+    _resetWebhookCache();
+    _resetRoutingState();
+  });
+
+  afterEach(() => {
+    if (savedToken === undefined) delete process.env.DISCORD_BOT_TOKEN;
+    else process.env.DISCORD_BOT_TOKEN = savedToken;
+    globalThis.fetch = originalFetch;
+  });
+
+  test("getOrCreateWebhook creates one when none exists", async () => {
+    installFetch({ list: [] });
+    const r = await getOrCreateWebhook(CH);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data).toEqual(WH);
+    // a POST to create was made
+    expect(calls.some((c) => /\/channels\/.+\/webhooks$/.test(c.url) && c.method === "POST")).toBe(true);
+  });
+
+  test("getOrCreateWebhook reuses an existing cc-fleet webhook (no create)", async () => {
+    installFetch({ list: [{ id: "existing", name: FLEET_WEBHOOK_NAME, token: "extok" }] });
+    const r = await getOrCreateWebhook(CH);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data).toEqual({ id: "existing", token: "extok" });
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  test("getOrCreateWebhook caches (second call makes no requests)", async () => {
+    installFetch({ list: [] });
+    await getOrCreateWebhook(CH);
+    const before = calls.length;
+    await getOrCreateWebhook(CH);
+    expect(calls.length).toBe(before);
+  });
+
+  test("executeWebhook posts to the webhook URL with persona, scoped mentions, NO bot auth", async () => {
+    installFetch({ list: [] });
+    const r = await executeWebhook(CH, {
+      username: "babelfish 🐠",
+      avatarUrl: "https://example/a.png",
+      content: "hello",
+    });
+    expect(r.ok).toBe(true);
+    const exec = calls.find((c) => /\/webhooks\/[^/]+\/[^/?]+/.test(c.url) && c.method === "POST")!;
+    expect(exec).toBeDefined();
+    expect(exec.url).toContain("wait=true");
+    // skipAuth: webhook execute must NOT carry a bot Authorization header
+    expect(exec.headers.has("Authorization")).toBe(false);
+    const body = JSON.parse(exec.body);
+    expect(body.username).toBe("babelfish 🐠");
+    expect(body.avatar_url).toBe("https://example/a.png");
+    expect(body.content).toBe("hello");
+    expect(body.allowed_mentions).toEqual({ parse: [] });
+  });
+
+  test("executeWebhook re-provisions and retries on a stale-webhook 404", async () => {
+    installFetch({ list: [], execStatus: [404, 200] });
+    const r = await executeWebhook(CH, { username: "x", content: "y" });
+    expect(r.ok).toBe(true);
+    // two execute attempts (404 then 200)
+    const execs = calls.filter((c) => /\/webhooks\/[^/]+\/[^/?]+/.test(c.url) && c.method === "POST");
+    expect(execs.length).toBe(2);
+  });
+
+  test("redactWebhookToken strips the secret token from a webhook path (no log leak)", () => {
+    expect(redactWebhookToken("/webhooks/123/secrettok?wait=true")).toBe("/webhooks/123/***?wait=true");
+    // non-webhook paths are unchanged
+    expect(redactWebhookToken("/channels/9/messages")).toBe("/channels/9/messages");
+  });
+});

--- a/webhook.ts
+++ b/webhook.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-agent webhook identity (#55).
+ *
+ * When webhook identity is enabled, `disc_send` posts each message via a single
+ * reused "fleet" webhook per channel, overriding `username` + `avatar_url` per
+ * message so each agent shows up as a distinct poster. The text stays in
+ * `content`, so other agents read it normally (a webhook message is an ordinary
+ * message with a `webhook_id`).
+ *
+ * Webhook EXECUTE authenticates via the URL token (no bot auth — `skipAuth`).
+ * Webhook CREATE/LIST uses the bot token (needs MANAGE_WEBHOOKS) and self-
+ * provisions: no manual Discord-UI setup.
+ */
+import { discordFetch, type DiscordResult } from "./api.ts";
+
+/** Canonical name of the one reused webhook per channel. */
+export const FLEET_WEBHOOK_NAME = "cc-fleet";
+
+interface WebhookRef {
+  id: string;
+  token: string;
+}
+
+interface DiscordWebhook {
+  id: string;
+  name?: string;
+  token?: string;
+}
+
+// channelId → {id, token}. Reused across sends so we don't hit the
+// 10-webhooks/channel cap (per-message username/avatar overrides give
+// unlimited identities from one webhook).
+const cache = new Map<string, WebhookRef>();
+
+/** For tests: clear the in-memory webhook cache. */
+export function _resetWebhookCache(): void {
+  cache.clear();
+}
+
+/**
+ * Get the channel's fleet webhook, creating it if absent. Reuses an existing
+ * `cc-fleet` webhook (that still exposes its token) before creating a new one.
+ */
+export async function getOrCreateWebhook(
+  channelId: string
+): Promise<DiscordResult<WebhookRef>> {
+  const cached = cache.get(channelId);
+  if (cached) return { ok: true, data: cached };
+
+  // Reuse an existing fleet webhook if one is present + still exposes its token.
+  const list = await discordFetch<DiscordWebhook[]>(`/channels/${channelId}/webhooks`);
+  if (list.ok && Array.isArray(list.data)) {
+    const existing = list.data.find((w) => w.name === FLEET_WEBHOOK_NAME && w.token);
+    if (existing && existing.token) {
+      const ref = { id: existing.id, token: existing.token };
+      cache.set(channelId, ref);
+      return { ok: true, data: ref };
+    }
+  } else if (!list.ok) {
+    return { ok: false, error: `webhook list failed: ${list.error}` };
+  }
+
+  // Create one (bot needs MANAGE_WEBHOOKS).
+  const created = await discordFetch<DiscordWebhook>(`/channels/${channelId}/webhooks`, {
+    method: "POST",
+    body: JSON.stringify({ name: FLEET_WEBHOOK_NAME }),
+  });
+  if (!created.ok) return { ok: false, error: `webhook create failed: ${created.error}` };
+  if (!created.data.token) {
+    return { ok: false, error: "created webhook has no token" };
+  }
+  const ref = { id: created.data.id, token: created.data.token };
+  cache.set(channelId, ref);
+  return { ok: true, data: ref };
+}
+
+export interface WebhookExecuteParams {
+  username: string;
+  avatarUrl?: string;
+  content: string;
+  embeds?: unknown[];
+}
+
+/**
+ * Post one message as a given persona via the channel's fleet webhook. Always
+ * scopes `allowed_mentions` to nothing by default — webhooks bypass AutoMod, so
+ * we never let message text mass-ping (agent `@dev-name` addressing is a text
+ * convention the watcher routes on, not a Discord ping). On a stale-webhook
+ * 404, the cache is invalidated and the webhook re-provisioned once.
+ */
+export async function executeWebhook(
+  channelId: string,
+  params: WebhookExecuteParams
+): Promise<DiscordResult<unknown>> {
+  const send = async (ref: WebhookRef): Promise<DiscordResult<unknown>> => {
+    const body: Record<string, unknown> = {
+      username: params.username,
+      content: params.content,
+      allowed_mentions: { parse: [] },
+    };
+    if (params.avatarUrl) body.avatar_url = params.avatarUrl;
+    if (params.embeds && params.embeds.length > 0) body.embeds = params.embeds;
+    return discordFetch(`/webhooks/${ref.id}/${ref.token}?wait=true`, {
+      method: "POST",
+      body: JSON.stringify(body),
+      skipAuth: true,
+    });
+  };
+
+  const ref = await getOrCreateWebhook(channelId);
+  if (!ref.ok) return ref;
+
+  const result = await send(ref.data);
+  // Stale webhook (deleted on Discord) → invalidate and re-provision once.
+  if (!result.ok && /HTTP 404/.test(result.error)) {
+    cache.delete(channelId);
+    const fresh = await getOrCreateWebhook(channelId);
+    if (!fresh.ok) return fresh;
+    return send(fresh.data);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
When `webhook_identity` is enabled and a `/name` identity exists, `disc_send` posts each chunk via a self-provisioned, reused per-channel `cc-fleet` webhook with the agent's own **username + deterministic avatar** — so a human juggling many concurrent agents can tell them apart at a glance. Text stays in `content`, so other agents read it normally. No server boost, no Nitro (researched). Replaces the embed-color approach (embeds break agent-readability).

**Stacked on #57** (surrogate sanitize) — base will retarget to `main` when #57 merges.

## Changes
- **`webhook.ts`** — `getOrCreateWebhook` (cache → reuse `cc-fleet` → self-provision via `MANAGE_WEBHOOKS`); `executeWebhook` (POST `/webhooks/{id}/{token}?wait=true` with username/avatar/content + `allowed_mentions:{parse:[]}`; stale-webhook **404 → re-provision + retry once**).
- **`api.ts`** — `discordFetch` gains `skipAuth` (webhook execute authenticates via the URL token, not the Bot header) + **`redactWebhookToken`** so the bearer token never lands in `~/.claude/logs/mcp.jsonl` (caught in review).
- **`identity.ts`** — read dev_name/avatar from the `/name` identity file; persona username (clyde/discord neutralization + trim + 80-cap) + deterministic DiceBear avatar.
- **`send.ts`** — flag-gated early-return webhook branch; falls back to the bot path when off / no identity / empty username / attachment present.

## Linked Issues
Closes #55

## Test Plan
- `bun test` → identity (12) + webhook (6) new tests; `validate.sh` **100 pass / 0 fail**; `tsc` clean.
- **Default (flag-off) path is an unchanged no-op** (verified).
- Code-reviewed: critical **token-in-logs leak** + trim/empty-name guard fixed; skipAuth/allowed_mentions/chunk-handling verified correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)