### PR TITLE
chore(disc): align in-repo version with release tag (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,17 @@ Initial release of `mcp-server-discord` — a Bun/TypeScript MCP server that exp
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-06-23
+
+> The changelog was not maintained across the `1.0.3`–`1.2.2` tags; this entry consolidates the changes published since `[1.0.0]` that were never separately recorded, alongside the new `1.3.0` work (#57, #58). In-repo version (`package.json`, `index.ts`) aligned to the `v1.3.0` tag (#63).
+
+### Added
+
+- **Per-agent webhook identity** — `disc_send` posts under a distinct username and avatar per agent, so multiple agents sharing a channel are visually distinguishable rather than collapsing onto one webhook identity. Fixes #58.
+
 ### Fixed
 
+- **Surrogate sanitization** — lone UTF-16 surrogate code units are now sanitized in **both** directions (inbound reads and outbound sends), preventing malformed-Unicode errors at the Discord API boundary. Fixes #57.
 - **`disc_send`** — Fixed message splitting bug where labeled chunks could exceed 2000 chars on content-dense input (markdown tables, code blocks). The splitter now accounts for label overhead (`(N/M) `) before splitting, ensuring all labeled chunks stay within Discord's 2000-char limit. Fixes #37.
 - **`disc_send`** — Validate the body field before dereferencing. Prior callers that supplied a different field name (most commonly `content`, which is what the upstream Discord REST API itself uses) hit an opaque `text.length` crash inside `splitMessage`. The handler now (a) accepts `content` as an alias for `message`, and (b) returns a structured error naming the missing field plus what was actually received when neither is supplied. Schema in `index.ts` documents the alias. Fixes #50.
 - **`tests/config.test.ts`** — Stop destroying real user secrets. Earlier versions of the test wrote and deleted `$HOME/secrets/discord-bot-token` and `$HOME/.claude/discord.json` directly via `homedir()`-derived paths, silently clobbering production secrets on every `bun test` run. Three confirmed losses on developer machines, surfaced via Linux audit log on 2026-04-28. Fix: every test now uses `$DISCORD_TOKEN_FILE` and the new `$DISCORD_CONFIG_FILE` env overrides pointing at a per-test tmpdir. A suite-wide SHA-guard in `beforeAll`/`afterAll` records and verifies the real-path SHAs are unchanged across the suite, failing loudly if any future test regresses isolation. `config.ts` now exposes `$DISCORD_CONFIG_FILE` for parity with the existing `$DISCORD_TOKEN_FILE`. Fixes #52.

--- a/index.ts
+++ b/index.ts
@@ -193,11 +193,11 @@ if (existsSync(KILL_SWITCH_PATH)) {
 }
 
 const server = new Server(
-  { name: "disc-server", version: "1.0.0" },
+  { name: "disc-server", version: "1.3.0" },
   { capabilities: { tools: {} } }
 );
 
-log.info("startup", { version: "1.0.0", config: { tools: TOOLS.length, kill_switch: false } });
+log.info("startup", { version: "1.3.0", config: { tools: TOOLS.length, kill_switch: false } });
 
 // Resolve API base URL (scream-hole or direct Discord) and log the decision
 await resolveApiBase();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-discord",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "MCP server for Discord channel management and messaging",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Aligns the stale in-repo version (`1.0.0`) with the release line ahead of cutting `v1.3.0`. Tags are at `v1.2.2`; bumps to `1.3.0` so the file matches the upcoming tag. Adds a CHANGELOG `[1.3.0]` section so the in-repo story matches the tag, not just the version string.

## Changes
- `package.json` + `index.ts` (×2): version `1.0.0` → `1.3.0`
- `CHANGELOG.md`: new `## [1.3.0]` consolidating #57 (surrogate sanitize) + #58 (per-agent webhook identity) plus previously-stranded `[Unreleased]` entries (#37/#50/#52), with a note acknowledging the un-recorded 1.0.3–1.2.2 history

## Linked Issues
Closes #63

## Test Plan
- `bunx tsc --noEmit` clean
- `bun test` — 100 pass / 7 skip / 0 fail
- opus code-review: important finding (missing CHANGELOG [1.3.0]) fixed; diff is exactly the version strings + changelog
- 3 trivy HIGH deferred (pre-existing transitive `fast-uri`/`hono` via MCP SDK, fleet-wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)